### PR TITLE
Add Future Collections

### DIFF
--- a/Sources/Future/Future.swift
+++ b/Sources/Future/Future.swift
@@ -1,3 +1,8 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
 import Foundation
 
 /**
@@ -29,7 +34,9 @@ blocks on the Future
 */
 
     public final class Resolver {
+        private(set) public var isResolved = false
         fileprivate weak var _future: Future<T, E>?
+        
         fileprivate init(_ future: Future<T, E>) {
             self._future = future
         }
@@ -80,7 +87,6 @@ immediately calls all catch() observers with the error.
     
     private func resolve(value: Value) {
         guard !self.isResolved else {
-            // TODO: Is returning early here the right decision?
             return
         }
         
@@ -90,7 +96,6 @@ immediately calls all catch() observers with the error.
     
     private func reject(error: Error) {
         guard !self.isResolved else {
-            // TODO: Is returning early here the right decision?
             return
         }
 

--- a/Sources/Future/Futures.swift
+++ b/Sources/Future/Futures.swift
@@ -1,0 +1,143 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
+import Foundation
+
+// ====--------------------------------------------------------====
+/*
+Future [Result|Error]Collections are thin wrappers around arrays (themselves
+available as .rawValue) in order to solve the [E] !== Swift.Error issue.
+*/
+
+extension Future {
+/**
+A thin wrapper around an array of values returned by a collection
+of Futures.
+     
+```
+     Futures.all([doAsyncThing(), doOtherAsyncThing()]).then { results in
+        let arrayValue = results.rawValue
+        // or...
+        let result = results[0]
+     }
+```
+*/
+    public struct ResultCollection {
+        fileprivate(set) public var rawValue = [T]()
+        
+        public subscript(_ index: Int) -> T {
+            return self.rawValue[index]
+        }
+    }
+    
+/**
+A thin wrapper around an array of errors returned by a collection
+of Futures.
+     
+```
+     Futures.all([doAsyncThing(), doOtherAsyncThing()]).catch { errors in
+        let arrayValue = errors
+        // or...
+        let result = results[0]
+     }
+```
+*/
+
+    public struct ErrorCollection: Swift.Error {
+        fileprivate(set) public var rawValue = [E]()
+        
+        public subscript(_ index: Int) -> E {
+            return self.rawValue[index]
+        }
+    }
+}
+
+// ====--------------------------------------------------------====
+
+public enum Futures {
+/**
+Returns a Future that will be resolved after all passed futures complete that will be successful if all of the original futures are
+successful. This method makes no assumption about order or thread delivery.
+*/
+    static func all<T: Any, E: Error>(_ futures: [Future<T, E>]) -> Future<Future<T, E>.ResultCollection, Future<T, E>.ErrorCollection> {
+        return Future { resolver in
+            var results = Future<T, E>.ResultCollection()
+            var errors = Future<T, E>.ErrorCollection()
+            let totalCount = futures.count
+            
+            futures.forEach { future in
+                future.always { result, error in
+                    if let result = result {
+                        results.rawValue.append(result)
+                    } else {
+                        errors.rawValue.append(error!)
+                    }
+                    
+                    let resolvedCount = results.rawValue.count + errors.rawValue.count
+                    if resolvedCount == totalCount {
+                        if errors.rawValue.isEmpty {
+                            resolver.resolve(value: results)
+                        } else {
+                            resolver.reject(error: errors)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+/**
+Returns a Future that will be resolved after all passed futures complete that will be successful if any of the original futures are
+successful. This method makes no assumption about order or thread delivery.
+*/
+
+    static func any<T: Any, E: Error>(_ futures: [Future<T , E>]) -> Future<Future<T, E>.ResultCollection, Future<T, E>.ErrorCollection> {
+        return Future { resolver in
+            var results = Future<T, E>.ResultCollection()
+            var errors = Future<T, E>.ErrorCollection()
+            let totalCount = futures.count
+            
+            futures.forEach { future in
+                future.always { result, error in
+                    if let result = result {
+                        results.rawValue.append(result)
+                    } else {
+                        errors.rawValue.append(error!)
+                    }
+                    
+                    let resolvedCount = results.rawValue.count + errors.rawValue.count
+                    if resolvedCount == totalCount {
+                        if results.rawValue.isEmpty {
+                            resolver.reject(error: errors)
+                        } else {
+                            resolver.resolve(value: results)
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+/**
+Returns a Future that will be resolved or rejected with the value or error of the first future to complete. If multiple
+Futures are already resolved at the time `first` is called, the first resolved future in the passed array will be used.
+*/
+
+    static func first<T: Any, E: Error>(_ futures: [Future<T, E>]) -> Future<T, E> {
+        return Future { resolver in
+            // Safe due to the feature that calling resolve on a resolved Future's resolver is, basically, a no-op
+            futures.forEach { future in
+                future.then { value in
+                    resolver.resolve(value: value)
+                    
+                }.catch { error in
+                    resolver.reject(error: error)
+                    
+                }
+            }
+        }
+    }
+}
+

--- a/Sources/Future/NoError.swift
+++ b/Sources/Future/NoError.swift
@@ -1,4 +1,14 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
 import Foundation
+
+/**
+An uninhabitable enum that can be used to denote when there is no
+possible error in a Future
+*/
 
 public enum NoError: Error {}
 

--- a/Tests/FutureTests/FutureAllTests.swift
+++ b/Tests/FutureTests/FutureAllTests.swift
@@ -1,0 +1,97 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
+import XCTest
+@testable import Future
+
+private enum FutureError: Int, Error {
+    case failure
+    case otherFailure
+}
+
+// ====--------------------------------------------------------====
+
+final class FutureAllTests: XCTestCase {
+    static var allTests = [
+        ("testLikeTypeFuturesAllSuccesses", testLikeTypeFuturesAllSuccesses),
+        ("testLikeTypeFuturesAllSomeSuccesses", testLikeTypeFuturesAllSomeSuccesses),
+        ("testLikeTypeFuturesAllNoSuccesses", testLikeTypeFuturesAllNoSuccesses)
+    ]
+    
+    func testLikeTypeFuturesAllSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.resolve(value: 1)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.resolve(value: 2)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.all will resolve")
+        let future = Futures.all([futureOne, futureTwo])
+        
+        future.then { results in
+            XCTAssertEqual(results.rawValue.count, 2)
+            expectation.fulfill()
+            
+        }.catch { _ in
+            XCTFail()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+    
+    func testLikeTypeFuturesAllSomeSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.resolve(value: 1)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.reject(error: .failure)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.all will reject")
+        let future = Futures.all([futureOne, futureTwo])
+        
+        future.then { _ in
+            XCTFail()
+            
+        }.catch { errors in
+            XCTAssertEqual(errors.rawValue.count, 1)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+    
+    func testLikeTypeFuturesAllNoSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.reject(error: .failure)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.reject(error: .failure)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.all will reject")
+        let future = Futures.all([futureOne, futureTwo])
+        
+        future.then { results in
+            XCTFail()
+            
+        }.catch { errors in
+            XCTAssertEqual(errors.rawValue.count, 2)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+}

--- a/Tests/FutureTests/FutureAnyTests.swift
+++ b/Tests/FutureTests/FutureAnyTests.swift
@@ -1,0 +1,97 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
+import XCTest
+@testable import Future
+
+private enum FutureError: Int, Error {
+    case failure
+    case otherFailure
+}
+
+// ====--------------------------------------------------------====
+
+final class FutureAnyTests: XCTestCase {
+    static var allTests = [
+        ("testLikeTypeFuturesAnyAllSuccesses", testLikeTypeFuturesAnyAllSuccesses),
+        ("testLikeTypeFuturesAnySomeSuccesses", testLikeTypeFuturesAnySomeSuccesses),
+        ("testLikeTypeFuturesAnyNoSuccesses", testLikeTypeFuturesAnyNoSuccesses)
+    ]
+    
+    func testLikeTypeFuturesAnyAllSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.resolve(value: 1)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.resolve(value: 2)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.any will resolve")
+        let future = Futures.any([futureOne, futureTwo])
+        
+        future.then { results in
+            XCTAssertEqual(results.rawValue.count, 2)
+            expectation.fulfill()
+            
+        }.catch { _ in
+            XCTFail()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+    
+    func testLikeTypeFuturesAnySomeSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.resolve(value: 1)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.reject(error: .failure)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.first will resolve")
+        let future = Futures.any([futureOne, futureTwo])
+        
+        future.then { results in
+            XCTAssertEqual(results.rawValue.count, 1)
+            expectation.fulfill()
+            
+        }.catch { _ in
+            XCTFail()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+
+    func testLikeTypeFuturesAnyNoSuccesses() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.reject(error: .failure)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.reject(error: .failure)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.first will reject")
+        let future = Futures.any([futureOne, futureTwo])
+        
+        future.then { results in
+            XCTFail()
+            
+        }.catch { errors in
+            XCTAssertEqual(errors.rawValue.count, 2)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+}

--- a/Tests/FutureTests/FutureFirstTests.swift
+++ b/Tests/FutureTests/FutureFirstTests.swift
@@ -1,0 +1,65 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
+import XCTest
+@testable import Future
+
+private enum FutureError: Int, Error {
+    case failure
+    case otherFailure
+}
+
+// ====--------------------------------------------------------====
+
+final class FutureFirstTests: XCTestCase {
+    static var allTests = [
+        ("testLikeTypeFuturesFirstSuccess", testLikeTypeFuturesFirstSuccess),
+        ("testLikeTypeFuturesFirstError", testLikeTypeFuturesFirstError)
+    ]
+    
+    func testLikeTypeFuturesFirstSuccess() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.resolve(value: 1)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.resolve(value: 2)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.first will resolve")
+        Futures.first([futureOne, futureTwo]).then { value in
+            XCTAssertEqual(value, 1)
+            expectation.fulfill()
+        }.catch { _ in
+            XCTFail()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+    
+    func testLikeTypeFuturesFirstError() {
+        let futureOne = Future<Int, FutureError> { resolver in
+            resolver.reject(error: .failure)
+        }
+        
+        let futureTwo = Future<Int, FutureError> { resolver in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                resolver.reject(error: .otherFailure)
+            }
+        }
+        
+        let expectation = self.expectation(description: "Futures.first will reject")
+        Futures.first([futureOne, futureTwo]).then { value in
+            XCTFail()
+        }.catch { error in
+            XCTAssertEqual(error, .failure)
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 0.5, handler: nil)
+    }
+}

--- a/Tests/FutureTests/FutureTests.swift
+++ b/Tests/FutureTests/FutureTests.swift
@@ -1,3 +1,8 @@
+// ====--------------------------------------------------------====
+// Futures
+// https://github.com/genius/future
+// ====--------------------------------------------------------====
+
 import XCTest
 @testable import Future
 
@@ -5,6 +10,8 @@ private enum FutureError: Int, Error {
     case failure
     case otherFailure
 }
+
+// ====--------------------------------------------------------====
 
 final class FutureTests: XCTestCase {
     static var allTests = [


### PR DESCRIPTION
In order to support the eventual goal of composition of Futures, we need a way to aggregate Values and Errors when returned to the caller. 

Also adds Futures.all(), Futures.any(), Futures.first() in order to actually use these Future Collections.